### PR TITLE
Updated CourseDetail.js fixing issue #12

### DIFF
--- a/client/src/components/CourseDetail.js
+++ b/client/src/components/CourseDetail.js
@@ -69,7 +69,7 @@ export default class CourseDetail extends Component {
                   {course.materialsNeeded &&
                     <li className="course--stats--list--item">
                       <h4>Materials Needed</h4>
-                      <ReactMarkdown source={course.materials} />
+                      <ReactMarkdown source={course.materialsNeeded} />
                     </li>
                   }
                 </ul>


### PR DESCRIPTION
Added "Needed" to "materialsNeeded" on line 72 in CourseDetail.js fixing the Materials Needed section in the Build a Basic Bookcase course.